### PR TITLE
add --wait=http which runs connect as soon as box is active

### DIFF
--- a/build.go
+++ b/build.go
@@ -45,7 +45,7 @@ func (b buildJob) Start(args Args) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	logger.Info.Println("done. Build id: ", id)
+	logger.Info.Println("done. Build ID: ", id)
 
 	logger.Info.Println("archiving")
 	srcArchive, err := archiveDir(srcDir)

--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ var (
 	errInvalidToken           = errors.New("The token is invalid")
 	errUnknownError           = errors.New("Unknown error occurred")
 	errBadResponse            = errors.New("Bad response from server")
-  errUnexpectedTermination = errors.New("Job ended without reaching desired state")
+	errUnexpectedTermination  = errors.New("Job ended without reaching desired state")
 )
 
 // Client is a reconfigure.io platform client.
@@ -254,14 +254,34 @@ func (p clientImpl) getStatus(jobType string, id string) string {
 
 func (p clientImpl) waitForStatus(jobType string, id string, targetStatus string) error {
 	status := StatusSubmitted
-	prevStatus := status
+	prevStatus := ""
 	for status != targetStatus {
 		status = strings.ToUpper(p.getStatus(jobType, id))
 		if status != prevStatus {
 			logger.Info.Println("status: ", status)
 			prevStatus = status
-			if status == StatusQueued && jobType == "deployment" {
-				logger.Info.Println("Waiting for EC2 instance to be allocated")
+			switch jobType {
+			case "deployment":
+				switch status {
+				case StatusQueued:
+					logger.Info.Println("Waiting for EC2 instance to be allocated")
+				case StatusSubmitted:
+					logger.Info.Println("Waiting for Spot Instance Request to be created")
+				default:
+				}
+			case "build":
+				switch status {
+				case StatusQueued:
+					logger.Info.Println("Waiting for Batch job to start")
+				default:
+				}
+			case "simulation":
+				switch status {
+				case StatusQueued:
+					logger.Info.Println("Waiting for Batch job to start")
+				default:
+				}
+			default:
 			}
 		}
 		if isCompleted(status) {
@@ -273,37 +293,10 @@ func (p clientImpl) waitForStatus(jobType string, id string, targetStatus string
 }
 
 func (p clientImpl) waitAndLog(jobType string, id string) error {
-	logger.Info.Println(`you can run "reco `, jobType, " log ", id, `" to manually stream logs`)
-	logger.Info.Println("getting ", jobType, " details")
-
-	getStatus := func() string {
-		job, err := p.getJob(jobType, id)
-		if err == nil && job.Status != "" {
-			return job.Status
-		}
-		return StatusWaiting
-	}
-
-	status := getStatus()
-	logger.Info.Println("status: ", status)
-
-	if jobType == "" || jobType == JobTypeBuild {
-		logger.Info.Println("this will take at least 4 hours")
-	} else {
-		logger.Info.Println("this may take several minutes")
-	}
-
-	logger.Info.Println("waiting for ", jobType, " to start")
-
-	body, err := p.waitForLog(jobType, id, true)
+	err := p.waitForStatus(jobType, id, StatusStarted)
 	if err != nil {
 		return err
 	}
-	defer body.Close()
-
-	logger.Info.Println("status: ", getStatus())
-	logger.Info.Println("streaming logs")
-	logger.Std.Println()
 	return p.logs(jobType, id)
 }
 

--- a/client.go
+++ b/client.go
@@ -250,6 +250,9 @@ func (p clientImpl) waitForStatus(jobType string, id string, targetStatus string
 		if status != prevStatus {
 			logger.Info.Println("status: ", status)
 			prevStatus = status
+			if status == StatusQueued && jobType == "deployment" {
+				logger.Info.Println("Waiting for EC2 instance to be allocated")
+			}
 		}
 		if isCompleted(status) {
 			return errUnexpectedTermination

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -7,9 +7,9 @@ import (
 )
 
 var deploymentVars = struct {
-	wait bool
+	wait string
 }{
-	wait: true,
+	wait: "true",
 }
 
 var deploymentCmdStart = &cobra.Command{
@@ -50,7 +50,7 @@ var deploymentCmdConnect = &cobra.Command{
 }
 
 func init() {
-	deploymentCmdStart.PersistentFlags().BoolVarP(&deploymentVars.wait, "wait", "w", deploymentVars.wait, "wait for the run to complete. If false, it only starts the command without waiting for it to complete.")
+	deploymentCmdStart.PersistentFlags().StringVarP(&deploymentVars.wait, "wait", "w", deploymentVars.wait, "wait for the run to complete. If false, it only starts the command without waiting for it to complete.")
 
 	deploymentCmd := genDevCommand("deployment", "d", "dep", "deps", "deployments")
 	deploymentCmd.AddCommand(deploymentCmdStart)

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -42,7 +42,7 @@ your command instead. The two forms are equivalent:
 }
 
 var deploymentCmdConnect = &cobra.Command{
-	Use:     "connect id",
+	Use:     "connect ID",
 	Aliases: []string{"c", "connects"},
 	Short:   "Connect to a running deployment",
 	Long:    "Connect to a running deployment",
@@ -83,7 +83,7 @@ func startDeployment(cmd *cobra.Command, args []string) {
 
 func connectDeployment(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		exitWithError("deployment id required")
+		exitWithError("deployment ID required")
 	}
 	if err := tool.Deployment().(reco.DeploymentProxy).Connect(args[0], true); err != nil {
 		exitWithError(err)

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -82,7 +82,7 @@ func connectDeployment(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
 		exitWithError("deployment id required")
 	}
-	if err := tool.Deployment().(reco.DeploymentProxy).Connect(args[0]); err != nil {
+	if err := tool.Deployment().(reco.DeploymentProxy).Connect(args[0], true); err != nil {
 		exitWithError(err)
 	}
 }

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -64,7 +64,7 @@ func generateGraph(cmd *cobra.Command, args []string) {
 
 func openGraph(_ *cobra.Command, args []string) {
 	if len(args) == 0 {
-		exitWithError("id required")
+		exitWithError("ID required")
 	}
 	file, err := tool.Graph().Open(args[0])
 	if err != nil {

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -11,13 +11,13 @@ import (
 
 var logPreRun = func(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		exitWithError("id required")
+		exitWithError("ID required")
 	}
 }
 
 func genLogSubcommand(name string, job string) *cobra.Command {
 	return &cobra.Command{
-		Use:     "log id",
+		Use:     "log ID",
 		Aliases: []string{"logs"},
 		Short:   fmt.Sprintf("Stream logs for a %s", name),
 		Long:    fmt.Sprintf("Stream logs for a %s previously started with 'reco %s run'", name, name),

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -11,13 +11,13 @@ import (
 
 var stopPreRun = func(cmd *cobra.Command, args []string) {
 	if len(args) == 0 {
-		exitWithError("id required")
+		exitWithError("ID required")
 	}
 }
 
 func genStopSubcommand(name string, job string) *cobra.Command {
 	return &cobra.Command{
-		Use:     "stop id",
+		Use:     "stop ID",
 		Aliases: []string{"s", "stp", "stops"},
 		Short:   fmt.Sprintf("Stop a %s", name),
 		Long:    fmt.Sprintf("Stop a %s previously started with 'reco %s run'", name, name),

--- a/deployment.go
+++ b/deployment.go
@@ -131,6 +131,7 @@ func (p deploymentJob) Log(id string, writer io.Writer) error {
 }
 
 func (p deploymentJob) Connect(id string) error {
+	logger.Info.Println("Waiting for deployment to listen on port 80")
 	for {
 		resp, err := p.clientImpl.getJob("deployment", id)
 		if err != nil {

--- a/deployment.go
+++ b/deployment.go
@@ -68,7 +68,11 @@ func (p deploymentJob) Start(args Args) (string, error) {
 	if wait == "true" {
 		return respJSON.Value.ID, p.waitAndLog("deployment", respJSON.Value.ID)
 	} else if wait == "http" {
-		return respJSON.Value.ID, p.Connect(respJSON.Value.ID, false)
+		err := p.waitForStatus("deployment", respJSON.Value.ID, StatusStarted)
+		if err == nil {
+			err = p.Connect(respJSON.Value.ID, false)
+		}
+		return respJSON.Value.ID, err
 	}
 	return "", nil
 }

--- a/deployment.go
+++ b/deployment.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"time"
 
@@ -141,7 +142,11 @@ func (p deploymentJob) Connect(id string) error {
 		}
 
 		if resp.IPAddress != "" {
-			return open.Run(fmt.Sprintf("http://%s/", resp.IPAddress))
+			conn, err := net.DialTimeout("tcp", resp.IPAddress+":80", 5*time.Second)
+			if conn != nil && err == nil {
+				_ = conn.Close()
+				return open.Run(fmt.Sprintf("http://%s/", resp.IPAddress))
+			}
 		}
 
 		time.Sleep(10 * time.Second)

--- a/deployment.go
+++ b/deployment.go
@@ -63,7 +63,7 @@ func (p deploymentJob) Start(args Args) (string, error) {
 		return "", errUnknownError
 	}
 
-	logger.Info.Println("done. Deployment id: ", respJSON.Value.ID)
+	logger.Info.Println("done. Deployment ID: ", respJSON.Value.ID)
 	logger.Info.Println(`you can run "reco deployment log `, respJSON.Value.ID, `" to manually stream logs`)
 	if wait == "true" {
 		return respJSON.Value.ID, p.waitAndLog("deployment", respJSON.Value.ID)

--- a/deployment.go
+++ b/deployment.go
@@ -29,7 +29,7 @@ type deploymentJob struct {
 func (p deploymentJob) Start(args Args) (string, error) {
 	buildID := String(args.At(0))
 	command := String(args.At(1))
-	wait := Bool(args.Last())
+	wait := String(args.Last())
 	cmdArgs := StringSlice(args.At(2))
 
 	req := p.apiRequest(endpoints.deployments.String())
@@ -64,8 +64,10 @@ func (p deploymentJob) Start(args Args) (string, error) {
 
 	logger.Info.Println("done. Deployment id: ", respJSON.Value.ID)
 	logger.Info.Println()
-	if wait {
+	if wait == "true" {
 		return respJSON.Value.ID, p.waitAndLog("deployment", respJSON.Value.ID)
+	} else if wait == "http" {
+		return respJSON.Value.ID, p.Connect(respJSON.Value.ID)
 	}
 	return "", nil
 }

--- a/deployment.go
+++ b/deployment.go
@@ -64,7 +64,7 @@ func (p deploymentJob) Start(args Args) (string, error) {
 	}
 
 	logger.Info.Println("done. Deployment id: ", respJSON.Value.ID)
-	logger.Info.Println()
+	logger.Info.Println(`you can run "reco deployment log `, respJSON.Value.ID, `" to manually stream logs`)
 	if wait == "true" {
 		return respJSON.Value.ID, p.waitAndLog("deployment", respJSON.Value.ID)
 	} else if wait == "http" {

--- a/graph.go
+++ b/graph.go
@@ -56,7 +56,7 @@ func (p platformGraph) Generate(args Args) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	logger.Info.Println("done. Graph id: ", id)
+	logger.Info.Println("done. Graph ID: ", id)
 
 	logger.Info.Println("archiving")
 	srcArchive, err := archiveDir(srcDir)

--- a/job.go
+++ b/job.go
@@ -68,7 +68,7 @@ func (ji *jobInfo) UnmarshalJSON(b []byte) error {
 		str.Project = str.Build.Project
 	}
 	ji.ID = str.ID
-	ji.Status = "unstarted"
+	ji.Status = StatusSubmitted
 	ji.Project = str.Project.Name
 	ji.Command = str.Command
 	ji.IPAddress = str.IPAddress


### PR DESCRIPTION
This changes the --wait flag from a bool to a string on deployments specifically. When `--wait=http` is specified during `reco deployment run` reco waits for the deployment to become active, then runs `connect` and opens your web browser pointed at the instance. Unfortunately connect doesn't check the instance is listening on port 80, it just waits for an IP address, but close enough.