### PR TITLE
if there's a timeout event report it to user

### DIFF
--- a/job.go
+++ b/job.go
@@ -39,7 +39,10 @@ var (
 	StatusCompleted = "COMPLETED"
 	// StatusErrored is errored job state.
 	StatusErrored = "ERRORED"
-	// StatusWaiting is waiting for events state
+	// An error event with code value 1 indicates timeout
+	StatusTimeout = "TIMEOUT"
+	// An error event with Code value 1 indicates timeout
+	ErrorCodeTimeout = 1
 )
 
 // jobInfo gives information about a build.
@@ -86,6 +89,15 @@ func (ji *jobInfo) UnmarshalJSON(b []byte) error {
 				lastEvent = ev
 			}
 		}
+		for _, event := range str.Job.Events {
+			if isTimeout(event) {
+				// Timeout isn't a Status reported by API
+				// but we know the error event was caused by a timeout
+				// so report that to user
+				lastEvent.Status = StatusTimeout
+			}
+		}
+
 		ji.Status = strings.ToLower(lastEvent.Status)
 		ji.Time = firstEvent.Timestamp
 		if eventSorter(str.Job.Events).Completed() {
@@ -161,6 +173,23 @@ func (job jobInfo) IsStarted() bool {
 func isStarted(status string) bool {
 	switch strings.ToUpper(status) {
 	case StatusCompleted, StatusErrored, StatusTerminated, StatusTerminating, StatusStarted, StatusCreatingImage:
+		return true
+	}
+	return false
+}
+
+func isTimeout(ev event) bool {
+	if isError(ev) {
+		if ev.Code == ErrorCodeTimeout {
+			return true
+		}
+	}
+	return false
+}
+
+func isError(ev event) bool {
+	switch strings.ToUpper(ev.Status) {
+	case StatusErrored:
 		return true
 	}
 	return false

--- a/job.go
+++ b/job.go
@@ -40,7 +40,7 @@ var (
 	// StatusErrored is errored job state.
 	StatusErrored = "ERRORED"
 	// An error event with code value 124 indicates timeout
-	StatusTimeout = "TIMEOUT"
+	StatusTimeout = "TIMED-OUT"
 	// An error event with Code value 124 indicates timeout
 	ErrorCodeTimeout = 124
 )

--- a/job.go
+++ b/job.go
@@ -39,10 +39,10 @@ var (
 	StatusCompleted = "COMPLETED"
 	// StatusErrored is errored job state.
 	StatusErrored = "ERRORED"
-	// An error event with code value 1 indicates timeout
+	// An error event with code value 124 indicates timeout
 	StatusTimeout = "TIMEOUT"
-	// An error event with Code value 1 indicates timeout
-	ErrorCodeTimeout = 1
+	// An error event with Code value 124 indicates timeout
+	ErrorCodeTimeout = 124
 )
 
 // jobInfo gives information about a build.


### PR DESCRIPTION
This should cause builds to show status `timeout` instead of `error` when a timeout has occurred. It does this by looking at the `code` field of the events of a job.
 

  
  