### PR TITLE
Add update command to let reco self-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ LDFLAGS := -X 'main.version=$(VERSION)' \
            -X 'main.buildTime=$(BUILDTIME)' \
            -X 'main.builder=$(BUILDER)' \
            -X 'main.goversion=$(GOVERSION)' \
+           -X 'main.target=$(TARGET)' \
            -X 'github.com/ReconfigureIO/reco.alternativePlatformServer=$(API_SERVER)'
 CODEBUILD_NAME := "sample-snap-builder"
 GO_EXTENSION :=
@@ -77,8 +78,7 @@ dist/%-${VERSION}-${TARGET}.zip: build/${TARGET}/%${GO_EXTENSION} | dist
 packages: $(PKG_TARGETS)
 
 install: $(TARGETS)
-	cp ${TARGETS} /usr/local/bin
-
+	cp ${TARGETS} /go/bin
 clean:
 	rm -rf ./dist $(TARGETS) ./build
 

--- a/client.go
+++ b/client.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ReconfigureIO/go-update"
 	"github.com/ReconfigureIO/reco/logger"
 	"github.com/spf13/viper"
 )
@@ -31,7 +30,6 @@ const (
 
 	platformServerKey     = "PLATFORM_SERVER"
 	platformServerAddress = "https://api.reconfigure.io"
-	recoDownloadAddress   = "https://s3.amazonaws.com/reconfigure.io/reco/releases/"
 	platformAuthFile      = "auth.json"
 	platformProjectFile   = "project.json"
 	StatusWaiting         = "WAITING"
@@ -75,7 +73,6 @@ type Client interface {
 	Project() ProjectConfig
 	// Graph handles graph actions.
 	Graph() Graph
-	Upgrade(string, string) error
 }
 
 var _ Client = &clientImpl{}
@@ -560,22 +557,4 @@ func inSlice(slice []string, val string) bool {
 		}
 	}
 	return false
-}
-
-func (p *clientImpl) Upgrade(version string, platform string) error {
-	//form URL from download endpoint and version string
-	//download zip
-	//hand off to go-update
-
-	downloadURL := recoDownloadAddress + "reco-" + version + "-" + platform + ".zip"
-	resp, err := http.Get(downloadURL)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	err = update.Apply(resp.Body, update.Options{})
-	if err != nil {
-		// error handling
-	}
-	return err
 }

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ReconfigureIO/go-update"
 	"github.com/ReconfigureIO/reco/logger"
 	"github.com/spf13/viper"
 )
@@ -30,6 +31,7 @@ const (
 
 	platformServerKey     = "PLATFORM_SERVER"
 	platformServerAddress = "https://api.reconfigure.io"
+	recoDownloadAddress   = "https://s3.amazonaws.com/reconfigure.io/reco/releases/"
 	platformAuthFile      = "auth.json"
 	platformProjectFile   = "project.json"
 	StatusWaiting         = "WAITING"
@@ -73,6 +75,7 @@ type Client interface {
 	Project() ProjectConfig
 	// Graph handles graph actions.
 	Graph() Graph
+	Upgrade(string, string) error
 }
 
 var _ Client = &clientImpl{}
@@ -557,4 +560,22 @@ func inSlice(slice []string, val string) bool {
 		}
 	}
 	return false
+}
+
+func (p *clientImpl) Upgrade(version string, platform string) error {
+	//form URL from download endpoint and version string
+	//download zip
+	//hand off to go-update
+
+	downloadURL := recoDownloadAddress + "reco-" + version + "-" + platform + ".zip"
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	err = update.Apply(resp.Body, update.Options{})
+	if err != nil {
+		// error handling
+	}
+	return err
 }

--- a/cmd/reco/main.go
+++ b/cmd/reco/main.go
@@ -8,6 +8,7 @@ func main() {
 	cmd.BuildInfo.BuildTime = buildTime
 	cmd.BuildInfo.Builder = builder
 	cmd.BuildInfo.GoVersion = goversion
+	cmd.BuildInfo.Target = target
 
 	// execute
 	cmd.Execute()
@@ -18,4 +19,5 @@ var (
 	buildTime string
 	builder   string
 	goversion string
+	target    string
 )

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/ReconfigureIO/cobra"
+	"github.com/ReconfigureIO/go-update"
+	"github.com/ReconfigureIO/reco/logger"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update reco to the latest version",
+	Run:   update,
+}
+
+func init() {
+	RootCmd.AddCommand(updateCmd)
+}
+
+func version(cmd *cobra.Command, args []string) {
+	if BuildInfo.Version == "" {
+		logger.Std.Println("reco version: untracked dev build")
+		logger.Std.Println("Cannot automatically update from this version")
+		return
+	}
+	logger.Std.Println("You are using reco version: ", BuildInfo.Version)
+	if BuildInfo.BuildTime != "" {
+		logger.Std.Println("Built at: ", BuildInfo.BuildTime)
+	}
+	latest, err := latestRelease()
+	if err != nil {
+		logger.Std.Println("Could not retrieve latest verion info from Github: ", err)
+		return
+	} else {
+		logger.Std.Println("The latest release is reco version: ", latest)
+	}
+
+	if latest != BuildInfo.Version {
+		logger.Std.Println("Run reco update --apply to upgrade", latest)
+	} else {
+		logger.Std.Println("You are using the latest version")
+		return
+	}
+
+	return
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/ReconfigureIO/cobra"
-	"github.com/ReconfigureIO/go-update"
+	//"github.com/ReconfigureIO/go-update"
 	"github.com/ReconfigureIO/reco/logger"
+	"github.com/google/go-github/github"
 )
 
 // updateCmd represents the update command
@@ -17,7 +20,7 @@ func init() {
 	RootCmd.AddCommand(updateCmd)
 }
 
-func version(cmd *cobra.Command, args []string) {
+func update(cmd *cobra.Command, args []string) {
 	if BuildInfo.Version == "" {
 		logger.Std.Println("reco version: untracked dev build")
 		logger.Std.Println("Cannot automatically update from this version")
@@ -27,7 +30,7 @@ func version(cmd *cobra.Command, args []string) {
 	if BuildInfo.BuildTime != "" {
 		logger.Std.Println("Built at: ", BuildInfo.BuildTime)
 	}
-	latest, err := latestRelease()
+	latest, err := latestRelease(github.NewClient(nil))
 	if err != nil {
 		logger.Std.Println("Could not retrieve latest verion info from Github: ", err)
 		return
@@ -43,4 +46,14 @@ func version(cmd *cobra.Command, args []string) {
 	}
 
 	return
+}
+
+// latestRelease gets the version number of the latest reco release
+func latestRelease(client *github.Client) (string, error) {
+	release, _, err := client.Repositories.GetLatestRelease(context.Background(), "ReconfigureIO", "reco")
+	if err != nil {
+		return "", err
+	}
+	logger.Std.Println("tagname is: ", *release.TagName)
+	return *release.TagName, nil
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -26,7 +26,7 @@ func update(cmd *cobra.Command, args []string) {
 		logger.Std.Println("Cannot automatically update from this version")
 		return
 	}
-	logger.Std.Println("You are using reco version: ", BuildInfo.Version)
+	logger.Std.Println("You are using reco ", BuildInfo.Version)
 	if BuildInfo.BuildTime != "" {
 		logger.Std.Println("Built at: ", BuildInfo.BuildTime)
 	}
@@ -35,11 +35,11 @@ func update(cmd *cobra.Command, args []string) {
 		logger.Std.Println("Could not retrieve latest verion info from Github: ", err)
 		return
 	} else {
-		logger.Std.Println("The latest release is reco version: ", latest)
+		logger.Std.Println("The latest release is reco ", latest)
 	}
 
 	if latest != BuildInfo.Version {
-		logger.Std.Println("Run reco update --apply to upgrade", latest)
+		logger.Std.Println("Run reco update --apply to upgrade to ", latest)
 	} else {
 		logger.Std.Println("You are using the latest version")
 		return
@@ -54,6 +54,5 @@ func latestRelease(client *github.Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	logger.Std.Println("tagname is: ", *release.TagName)
 	return *release.TagName, nil
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -20,14 +20,19 @@ const (
 )
 
 // updateCmd represents the update command
-var updateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update reco to the latest version",
-	Run:   updateHandler,
-}
+var (
+	updateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update reco to the latest version",
+		Run:   updateHandler,
+	}
+
+	justDoIt bool
+)
 
 func init() {
 	RootCmd.AddCommand(updateCmd)
+	updateCmd.PersistentFlags().BoolVar(&justDoIt, "just-do-it", justDoIt, "Download and apply update without user interaction")
 }
 
 func updateHandler(cmd *cobra.Command, args []string) {
@@ -48,12 +53,20 @@ func updateHandler(cmd *cobra.Command, args []string) {
 		logger.Std.Println("The latest release is reco ", latest)
 	}
 
+	if justDoIt {
+		err = UpgradeTo(latest, BuildInfo.Target)
+		if err != nil {
+			exitWithError(err)
+		} else {
+			return
+		}
+	}
+
 	if latest != BuildInfo.Version {
 		logger.Std.Println("Would you like to upgrade? (Y/N)")
 		upgrade := askForConfirmation()
 		if upgrade == true {
 			if err := UpgradeTo(latest, BuildInfo.Target); err != nil {
-				logger.Std.Println("oh dear")
 				exitWithError(err)
 			}
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -42,9 +42,6 @@ func updateHandler(cmd *cobra.Command, args []string) {
 		return
 	}
 	logger.Std.Println("You are using reco ", BuildInfo.Version)
-	if BuildInfo.BuildTime != "" {
-		logger.Std.Println("Built at: ", BuildInfo.BuildTime)
-	}
 	latest, err := latestRelease(github.NewClient(nil))
 	if err != nil {
 		logger.Std.Println("Could not retrieve latest verion info from Github: ", err)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func TestLatestRelease(t *testing.T) {
+	latest, err := latestRelease(github.NewClient(nil))
+	if err != nil {
+		t.Error(err)
+	}
+	if latest == "" {
+		t.Error("Returned string is empty")
+	}
+	fmt.Println(latest)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"github.com/ReconfigureIO/reco/logger"
 	"github.com/ReconfigureIO/cobra"
+	"github.com/ReconfigureIO/reco/logger"
 )
 
 // BuildInfo is the build information of reco binary. This is
 // set at build time by ldflags.
 var BuildInfo struct {
-	Version, BuildTime, Builder, GoVersion string
+	Version, BuildTime, Builder, GoVersion, Target string
 }
 
 // versionCmd represents the version command

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3f8fd0f68a47d3a138a529584f903f6f425c73ba70d2cd2a9483393d489a6d0d
-updated: 2018-02-14T16:41:54.578618475Z
+updated: 2018-02-15T17:23:51.960619003Z
 imports:
 - name: github.com/abiosoft/goutils
   version: af27f2043be5f6bf2388ddb35cc93a70b9037365
@@ -75,7 +75,7 @@ imports:
 - name: github.com/ReconfigureIO/cobra
   version: 3b4ffe4b37381957c28404f5e069ba5bca001d36
 - name: github.com/ReconfigureIO/go-update
-  version: 8152e7eb6ccf8679a64582a66b78519688d156ad
+  version: bf22c9dcdbb2c8d58308f9fbefc34ea0e64bd61d
 - name: github.com/skratchdot/open-golang
   version: 75fb7ed4208cf72d323d7d02fd1a5964a7a9073c
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3f8fd0f68a47d3a138a529584f903f6f425c73ba70d2cd2a9483393d489a6d0d
-updated: 2018-01-25T10:53:04.460875406Z
+updated: 2018-02-14T16:41:54.578618475Z
 imports:
 - name: github.com/abiosoft/goutils
   version: af27f2043be5f6bf2388ddb35cc93a70b9037365
@@ -19,6 +19,14 @@ imports:
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
+- name: github.com/google/go-github
+  version: 632a2caf6d3d380753dc7e422748202982ad18a3
+  subpackages:
+  - github
+- name: github.com/google/go-querystring
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
+  subpackages:
+  - query
 - name: github.com/hashicorp/hcl
   version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
@@ -31,6 +39,11 @@ imports:
   - json/parser
   - json/scanner
   - json/token
+- name: github.com/inconshreveable/go-update
+  version: 8152e7eb6ccf8679a64582a66b78519688d156ad
+  subpackages:
+  - internal/binarydist
+  - internal/osext
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/magiconair/properties
@@ -61,6 +74,8 @@ imports:
   version: ec41b3af3a74d34f368868a57ef01ced8b8e9568
 - name: github.com/ReconfigureIO/cobra
   version: 3b4ffe4b37381957c28404f5e069ba5bca001d36
+- name: github.com/ReconfigureIO/go-update
+  version: 8152e7eb6ccf8679a64582a66b78519688d156ad
 - name: github.com/skratchdot/open-golang
   version: 75fb7ed4208cf72d323d7d02fd1a5964a7a9073c
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3f8fd0f68a47d3a138a529584f903f6f425c73ba70d2cd2a9483393d489a6d0d
-updated: 2018-02-15T17:23:51.960619003Z
+updated: 2018-02-16T11:58:06.879757929Z
 imports:
 - name: github.com/abiosoft/goutils
   version: af27f2043be5f6bf2388ddb35cc93a70b9037365
@@ -39,11 +39,6 @@ imports:
   - json/parser
   - json/scanner
   - json/token
-- name: github.com/inconshreveable/go-update
-  version: 8152e7eb6ccf8679a64582a66b78519688d156ad
-  subpackages:
-  - internal/binarydist
-  - internal/osext
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/magiconair/properties
@@ -76,6 +71,9 @@ imports:
   version: 3b4ffe4b37381957c28404f5e069ba5bca001d36
 - name: github.com/ReconfigureIO/go-update
   version: bf22c9dcdbb2c8d58308f9fbefc34ea0e64bd61d
+  subpackages:
+  - internal/binarydist
+  - internal/osext
 - name: github.com/skratchdot/open-golang
   version: 75fb7ed4208cf72d323d7d02fd1a5964a7a9073c
   subpackages:


### PR DESCRIPTION
This PR adds the `update` command and `--just-do-it` flags. When run, `reco update` finds the version number of the latest release on github. It then downloads this release for your platform and performs an in-place upgrade. The `--just-do-it` flag skips the 'would you like to upgrade?' question. 

```
$ reco update
You are using reco v0.4.4-6-g8dee5f8-dirty
The latest release is reco v0.4.4
Would you like to upgrade? (Y/N)
Y
Self-update successful

$ reco update --just-do-it
You are using reco v0.4.4-6-g8dee5f8-dirty
The latest release is reco v0.4.4
Self-update successful
```