### PR TITLE
Anything returned by reco log should be logs or an error

### DIFF
--- a/client.go
+++ b/client.go
@@ -247,8 +247,6 @@ func decodeJSON(r io.Reader, body interface{}) error {
 }
 
 func (p clientImpl) logJob(eventType string, id string) error {
-	logger.Info.Println("Beginning log stream for ", eventType, " ", id)
-	logger.Info.Println()
 	return p.logs(eventType, id)
 }
 


### PR DESCRIPTION
This PR removes the "beginning logstream for X" message. Now `reco log` behaves like other tools in that it only returns logs or an error. 