### PR TITLE
Make Reco graph gen requirements less stringent

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -53,7 +53,7 @@ func init() {
 }
 
 func generateGraph(cmd *cobra.Command, args []string) {
-	if !validBuildDir(srcDir) {
+	if !validGraphDir(srcDir) {
 		exitWithError(errInvalidSourceDirectory)
 	}
 	id, err := tool.Graph().Generate(reco.Args{srcDir})
@@ -88,4 +88,12 @@ func openGraph(_ *cobra.Command, args []string) {
 		logger.Std.Printf("Your graph is available here: %s", file)
 		return
 	}
+}
+
+func validGraphDir(srcDir string) bool {
+	// Do we have a main.go to graph?
+	if !hasMain(srcDir) {
+		return false
+	}
+	return true
 }

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os/exec"
 	"runtime"
 

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -41,6 +41,8 @@ This attempts to use your default pdf viewer to open the graph.
 	Run: openGraph,
 }
 
+var errInvalidGraphSourceDirectory = errors.New("Invalid source directory. Directory must have a main.go file")
+
 func init() {
 	graphCmd.AddCommand(
 		graphCmdGenerate,
@@ -54,7 +56,7 @@ func init() {
 
 func generateGraph(cmd *cobra.Command, args []string) {
 	if !validGraphDir(srcDir) {
-		exitWithError(errInvalidSourceDirectory)
+		exitWithError(errInvalidGraphSourceDirectory)
 	}
 	id, err := tool.Graph().Generate(reco.Args{srcDir})
 	if err != nil {


### PR DESCRIPTION
The requirements for a directory to have `reco build` run include having directories with host-side code. A graph doesn't need this, it only needs a `main.go` file. This PR makes that the case.