### PR TITLE
interpret the error returned from request.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ var (
 	errProjectNotCreated      = errors.New("No projects found. Run 'reco project create' to create one")
 	errProjectNotFound        = errors.New("Project not found. Run 'reco project list' to view all your available projects")
 	errNetworkError           = errors.New("Network error")
-	errNotFound               = errors.New("Not found")
+	ErrNotFound               = errors.New("Not found")
 	errInvalidToken           = errors.New("The token is invalid")
 	errUnknownError           = errors.New("Unknown error occurred")
 	errBadResponse            = errors.New("Bad response from server")

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -18,7 +18,7 @@ var (
 		wait: "true",
 	}
 
-	errorDeploymentNotFound = errors.New("No deployment with that ID could be found")
+	errorDeploymentNotFound = errors.New("No deployment with that ID could be found. Run 'reco deploy list' to view available deployments")
 
 	deploymentCmdStart = &cobra.Command{
 		Use:     "run [flags] <build_ID> <your_cmd> -- [args]",

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -87,7 +87,6 @@ your command. The two forms are equivalent:
 		Run: func(cmd *cobra.Command, args []string) {
 			l := reflect.ValueOf(tool).MethodByName("Deployment").Call(nil)[0].Interface()
 			if err := l.(reco.Job).Stop(args[0]); err != nil {
-
 				exitWithError(interpretError(err))
 			}
 			logger.Std.Printf("deployment stopped successfully")

--- a/deployment.go
+++ b/deployment.go
@@ -120,7 +120,7 @@ func (p deploymentJob) List(filter M) (printer.Table, error) {
 	}
 
 	table = printer.Table{
-		Header: []string{"id", "image", "command", "status", "started", "duration"},
+		Header: []string{"deployment id", "build id", "command", "status", "started", "duration"},
 		Body:   body,
 	}
 	if allProjects {

--- a/request.go
+++ b/request.go
@@ -139,7 +139,7 @@ func (p *clientRequest) Do(method string, body interface{}) (*http.Response, err
 		case 401, 403:
 			err = errAuthFailed
 		case 404:
-			err = errNotFound
+			err = ErrNotFound
 		}
 	} else if err != nil {
 		err = errNetworkError


### PR DESCRIPTION
Request.go generates a generic "Not Found" error when it gets a 404 from the API. We pass that back up the chain and report it to the user. That error could be a lot more specific if we interpret it at a level where we know what it was we were trying to access. This PR adds that interpreter at the command level so we can say 'deployment not found'.