### PR TITLE
do not poke github unless we're running integration tests

### DIFF
--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package cmd
 
 import (


### PR DESCRIPTION
`TestLatestRelease` asks github for the latest release of Reco and checks the response isn't empty. Since it talks to an external service it should only be run manually. This PR tags that test with `integration` so it will not be run by a normal `go test` but only when `--tags integration` is specified.