### PR TITLE
Make graph gen produce better guidance on viewing the output

### DIFF
--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -60,7 +60,8 @@ func generateGraph(cmd *cobra.Command, args []string) {
 	if err != nil {
 		exitWithError(err)
 	}
-	logger.Std.Println(id)
+	logger.Std.Println("Graph submitted. Run 'reco graph list' to track the status of your graph")
+	logger.Std.Println("Once the graph has been completed run 'reco graph open " + id + "' to view it")
 }
 
 func openGraph(_ *cobra.Command, args []string) {


### PR DESCRIPTION
```
$ reco graph gen
preparing graph
done. Graph ID: 33c5c177-facb-46a8-a591-31e71a795df4
archiving
done
uploading
done

Graph submitted. Run 'reco graph list' to track the status of your graph
Once the graph has been completed run 'reco graph open 33c5c177-facb-46a8-a591-31e71a795df4' to view it
```