### PR TITLE
Do not overwrite network errors.

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func (p *clientImpl) Auth(token string) error {
 	req := p.apiRequest(endpoints.users.String())
 	_, err := req.Do("GET", nil)
 	if err != nil {
-		return errAuthFailedInvalidToken
+		return err
 	} else {
 		err = p.saveAuth()
 		if err != nil {


### PR DESCRIPTION
In the event of a network error reco currently outputs errors about an invalid token. This PR reports the error returned by request.go which may be 'invalid token' or a network error.