### PR TITLE
Avoid reflection; use interfaces

### DIFF
--- a/build.go
+++ b/build.go
@@ -12,7 +12,7 @@ import (
 var _ Job = &buildJob{}
 
 type buildJob struct {
-	clientImpl
+	*clientImpl
 }
 
 func (b buildJob) prepareBuild() (string, error) {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/ReconfigureIO/cobra"
@@ -39,8 +38,7 @@ var (
 		Long:    fmt.Sprintf("Stream logs for a build previously started with 'reco build run'."),
 		PreRun:  buildLogPreRun,
 		Run: func(cmd *cobra.Command, args []string) {
-			l := reflect.ValueOf(tool).MethodByName("Build").Call(nil)[0].Interface()
-			if err := l.(reco.Job).Log(args[0], os.Stdout); err != nil {
+			if err := tool.Build().Log(args[0], os.Stdout); err != nil {
 				exitWithError(err)
 			}
 		},
@@ -59,8 +57,7 @@ var (
 		Long:    fmt.Sprintf("Stop a build previously started with 'reco build run'"),
 		PreRun:  buildStopPreRun,
 		Run: func(cmd *cobra.Command, args []string) {
-			l := reflect.ValueOf(tool).MethodByName("Build").Call(nil)[0].Interface()
-			if err := l.(reco.Job).Stop(args[0]); err != nil {
+			if err := tool.Build().Stop(args[0]); err != nil {
 				exitWithError(err)
 			}
 			logger.Std.Printf("build stopped successfully")
@@ -79,7 +76,7 @@ func init() {
 	buildCmdStart.PersistentFlags().BoolVarP(&buildVars.force, "force", "f", buildVars.force, "Force a build to start. Ignore source code validation")
 
 	buildCmd := genDevCommand("build", "build", "b", "builds")
-	buildCmd.AddCommand(genListSubcommand("builds", "Build"))
+	buildCmd.AddCommand(genListSubcommand("builds", tool.Build()))
 	buildCmd.AddCommand(buildCmdLog)
 	buildCmd.AddCommand(buildCmdStop)
 	buildCmd.AddCommand(buildCmdStart)

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 
 	"github.com/ReconfigureIO/cobra"
 	"github.com/ReconfigureIO/reco"
@@ -65,8 +64,7 @@ your command. The two forms are equivalent:
 		Long:    fmt.Sprintf("Stream logs for a deployment previously started with 'reco deploy run'."),
 		PreRun:  deploymentLogPreRun,
 		Run: func(cmd *cobra.Command, args []string) {
-			l := reflect.ValueOf(tool).MethodByName("Deployment").Call(nil)[0].Interface()
-			if err := l.(reco.Job).Log(args[0], os.Stdout); err != nil {
+			if err := tool.Deployment().Log(args[0], os.Stdout); err != nil {
 				exitWithError(interpretErrorDeployment(err))
 			}
 		},
@@ -85,8 +83,7 @@ your command. The two forms are equivalent:
 		Long:    fmt.Sprintf("Stop a deployment previously started with 'reco deploy run'"),
 		PreRun:  deploymentStopPreRun,
 		Run: func(cmd *cobra.Command, args []string) {
-			l := reflect.ValueOf(tool).MethodByName("Deployment").Call(nil)[0].Interface()
-			if err := l.(reco.Job).Stop(args[0]); err != nil {
+			if err := tool.Deployment().Stop(args[0]); err != nil {
 				exitWithError(interpretErrorDeployment(err))
 			}
 			logger.Std.Printf("deployment stopped successfully")
@@ -104,7 +101,7 @@ func init() {
 	deploymentCmdStart.PersistentFlags().StringVarP(&deploymentVars.wait, "wait", "w", deploymentVars.wait, "Wait for the run to complete. If false, it only starts the command without waiting for it to complete")
 
 	deploymentCmd := genDevCommand("deploy", "deployment", "d", "dep", "deps", "deployments", "deployment")
-	deploymentCmd.AddCommand(genListSubcommand("deployments", "Deployment"))
+	deploymentCmd.AddCommand(genListSubcommand("deployments", tool.Deployment()))
 	deploymentCmd.AddCommand(deploymentCmdLog)
 	deploymentCmd.AddCommand(deploymentCmdStop)
 	deploymentCmd.AddCommand(deploymentCmdStart)

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -50,7 +50,7 @@ func init() {
 	graphCmd.AddCommand(
 		graphCmdGenerate,
 		graphCmdOpen,
-		genListSubcommand("graphs", "Graph"),
+		genListSubcommand("graphs", tool.Graph()),
 	)
 	graphCmd.PersistentFlags().StringVar(&project, "project", project, "Project to use. If unset, the active project is used")
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"reflect"
 	"strconv"
 
 	"github.com/ReconfigureIO/cobra"
@@ -113,7 +112,6 @@ func listProject(cmd *cobra.Command, args []string) {
 	}
 
 	listVars.resourceType = "project"
-	l := reflect.ValueOf(tool).MethodByName("Project").Call(nil)[0].Interface()
-	listVars.table, listVars.err = l.(lister).List(filters)
+	listVars.table, listVars.err = tool.Project().List(filters)
 	listCmdAddFlags(cmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var cfgFile string
 var provider string
 var project string
 var srcDir string
-var tool reco.Client
+var tool reco.Client = reco.NewClient()
 
 var errInvalidSourceDirectory = errors.New("invalid source directory. Directory and all cmd/<directory> subdirectories must have a main.go file")
 
@@ -85,7 +85,6 @@ func initConfig() {
 
 func initTool() {
 	viper.Set("project", project)
-	tool = reco.NewClient()
 	if err := tool.Init(); err != nil {
 		exitWithError(err)
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/ReconfigureIO/cobra"
@@ -30,8 +29,7 @@ var (
 		Long:    fmt.Sprintf("Stream logs for a simulation previously started with 'reco sim run'."),
 		PreRun:  testLogPreRun,
 		Run: func(cmd *cobra.Command, args []string) {
-			l := reflect.ValueOf(tool).MethodByName("Test").Call(nil)[0].Interface()
-			if err := l.(reco.Job).Log(args[0], os.Stdout); err != nil {
+			if err := tool.Test().Log(args[0], os.Stdout); err != nil {
 				exitWithError(err)
 			}
 		},
@@ -50,8 +48,7 @@ var (
 		Long:    fmt.Sprintf("Stop a simulation previously started with 'reco sim run'"),
 		PreRun:  testStopPreRun,
 		Run: func(cmd *cobra.Command, args []string) {
-			l := reflect.ValueOf(tool).MethodByName("Test").Call(nil)[0].Interface()
-			if err := l.(reco.Job).Stop(args[0]); err != nil {
+			if err := tool.Test().Stop(args[0]); err != nil {
 				exitWithError(err)
 			}
 			logger.Std.Printf("Simulation stopped successfully")
@@ -67,7 +64,7 @@ var (
 
 func init() {
 	testCmd := genDevCommand("sim", "simulation", "simulation", "simulations", "test", "tests", "t")
-	testCmd.AddCommand(genListSubcommand("simulations", "Test"))
+	testCmd.AddCommand(genListSubcommand("simulations", tool.Test()))
 	testCmd.AddCommand(testCmdLog)
 	testCmd.AddCommand(testCmdStop)
 	testCmd.AddCommand(testCmdStart)

--- a/deployment.go
+++ b/deployment.go
@@ -24,7 +24,7 @@ var _ Job = deploymentJob{}
 var _ DeploymentProxy = deploymentJob{}
 
 type deploymentJob struct {
-	clientImpl
+	*clientImpl
 }
 
 func (p deploymentJob) Start(args Args) (string, error) {

--- a/graph.go
+++ b/graph.go
@@ -23,7 +23,7 @@ type Graph interface {
 var _ Graph = &platformGraph{}
 
 type platformGraph struct {
-	clientImpl
+	*clientImpl
 }
 
 func (b platformGraph) prepareGraph() (string, error) {

--- a/project.go
+++ b/project.go
@@ -35,7 +35,7 @@ type ProjectInfo struct {
 }
 
 type platformProject struct {
-	p clientImpl
+	p *clientImpl
 }
 
 func (p platformProject) List(filter M) (printer.Table, error) {

--- a/simulation.go
+++ b/simulation.go
@@ -13,7 +13,7 @@ import (
 var _ Job = &testJob{}
 
 type testJob struct {
-	clientImpl
+	*clientImpl
 }
 
 func (t testJob) prepareTest(command string) (string, error) {


### PR DESCRIPTION
I think reflection was used here because 'tool' wasn't available until Init had been run. Instead, the `NewClient` invocation is hoisted to the global variable definition, and the reflection becomes unnecessary.

Furthermore, the `clientImpl` was being passed around by value quite a lot, and therefore copied. Copies were being taken of its state before `loadAuth` was called, resulting in requests lacking a token. Instead, we now only have one global `clientImpl`, which is constructed at variable initialisation time.

The motivation for this is to complete the rename of 'test' to 'simulation': gorename can't see through the reflection.