### PR TITLE
Mechanical whitespace fixes

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -279,7 +279,6 @@ func (r recocheckDep) makeVirtualGoPath() error {
 	stat, err := os.Stat(vendorDir)
 
 	if err != nil {
-
 		if pErr, ok := err.(*os.PathError); ok {
 			switch pErr.Err.Error() {
 			case os.ErrNotExist.Error():

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -33,5 +33,4 @@ func TestMakeVirtualGoPathWorksIfVendor(t *testing.T) {
 	}
 
 	os.RemoveAll(vendorDir)
-
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,6 @@ func init() {
 	// hide provider and config. It is for internal use
 	RootCmd.PersistentFlags().MarkHidden("provider")
 	RootCmd.PersistentFlags().MarkHidden("config")
-
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/job_test.go
+++ b/job_test.go
@@ -61,7 +61,6 @@ func TestIsCompleted(t *testing.T) {
 			t.Error("IsCompleted returned true when it should be false")
 		}
 	}
-
 }
 
 func TestIsStarted(t *testing.T) {
@@ -75,5 +74,4 @@ func TestIsStarted(t *testing.T) {
 			t.Error("IsStarted returned true when it should be false")
 		}
 	}
-
 }


### PR DESCRIPTION
Some functions start with a blank line, some end with a blank line.

It's a minor inconsistency, but it is easy to mechanically fix:

```
find . -iname '*.go' | xargs perl -0777 -i -pe 's/{\n\n/{\n/igs'
find . -iname '*.go' | xargs perl -0777 -i -pe 's/\n\n}/\n}/igs'
```