### PR TITLE
Add ability to set messages on build creation

### DIFF
--- a/build.go
+++ b/build.go
@@ -15,13 +15,13 @@ type buildJob struct {
 	*clientImpl
 }
 
-func (b buildJob) prepareBuild() (string, error) {
+func (b buildJob) prepareBuild(comment string) (string, error) {
 	projectID, err := b.projectID()
 	if err != nil {
 		return "", err
 	}
 	req := b.apiRequest(endpoints.builds.String())
-	reqBody := M{"project_id": projectID}
+	reqBody := M{"project_id": projectID, "comment": comment}
 	resp, err := req.Do("POST", reqBody)
 	if err != nil {
 		return "", err
@@ -39,9 +39,10 @@ func (b buildJob) prepareBuild() (string, error) {
 func (b buildJob) Start(args Args) (string, error) {
 	srcDir := String(args.At(0))
 	wait := Bool(args.At(1))
+	comment := String(args.At(2))
 
 	logger.Info.Println("preparing build")
-	id, err := b.prepareBuild()
+	id, err := b.prepareBuild(comment)
 	if err != nil {
 		return "", err
 	}
@@ -95,6 +96,7 @@ func (b buildJob) List(filter M) (printer.Table, error) {
 			build.Status,
 			buildTime,
 			timeRounder(build.Duration).Nearest(time.Second),
+			build.Comment,
 		}
 		if allProjects {
 			row = append(row, build.Project)

--- a/build.go
+++ b/build.go
@@ -15,13 +15,13 @@ type buildJob struct {
 	*clientImpl
 }
 
-func (b buildJob) prepareBuild(comment string) (string, error) {
+func (b buildJob) prepareBuild(message string) (string, error) {
 	projectID, err := b.projectID()
 	if err != nil {
 		return "", err
 	}
 	req := b.apiRequest(endpoints.builds.String())
-	reqBody := M{"project_id": projectID, "comment": comment}
+	reqBody := M{"project_id": projectID, "message": message}
 	resp, err := req.Do("POST", reqBody)
 	if err != nil {
 		return "", err
@@ -39,10 +39,10 @@ func (b buildJob) prepareBuild(comment string) (string, error) {
 func (b buildJob) Start(args Args) (string, error) {
 	srcDir := String(args.At(0))
 	wait := Bool(args.At(1))
-	comment := String(args.At(2))
+	message := String(args.At(2))
 
 	logger.Info.Println("preparing build")
-	id, err := b.prepareBuild(comment)
+	id, err := b.prepareBuild(message)
 	if err != nil {
 		return "", err
 	}
@@ -96,7 +96,7 @@ func (b buildJob) List(filter M) (printer.Table, error) {
 			build.Status,
 			buildTime,
 			timeRounder(build.Duration).Nearest(time.Second),
-			build.Comment,
+			build.Message,
 		}
 		if allProjects {
 			row = append(row, build.Project)

--- a/build.go
+++ b/build.go
@@ -106,7 +106,7 @@ func (b buildJob) List(filter M) (printer.Table, error) {
 	}
 
 	table = printer.Table{
-		Header: []string{"build id", "status", "started", "duration"},
+		Header: []string{"build id", "status", "started", "duration", "message"},
 		Body:   body,
 	}
 	if allProjects {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -13,8 +13,9 @@ import (
 
 var (
 	buildVars = struct {
-		wait  bool
-		force bool
+		wait    bool
+		force   bool
+		comment string
 	}{
 		wait: true,
 	}
@@ -74,6 +75,7 @@ var (
 func init() {
 	buildCmdStart.PersistentFlags().BoolVarP(&buildVars.wait, "wait", "w", buildVars.wait, "Wait for the build to complete. If wait=false, logs will only be displayed up to where the build is started and assigned its unique ID. Use 'reco build list' to check the status of your builds")
 	buildCmdStart.PersistentFlags().BoolVarP(&buildVars.force, "force", "f", buildVars.force, "Force a build to start. Ignore source code validation")
+	buildCmdStart.PersistentFlags().StringVarP(&buildVars.comment, "comment", "m", buildVars.comment, "Add a comment to describe this build's purpose")
 
 	buildCmd := genDevCommand("build", "build", "b", "builds")
 	buildCmd.AddCommand(genListSubcommand("builds", tool.Build()))
@@ -90,7 +92,7 @@ func startBuild(cmd *cobra.Command, args []string) {
 		exitWithError(errInvalidSourceDirectory)
 	}
 
-	id, err := tool.Build().Start(reco.Args{srcDir, buildVars.wait})
+	id, err := tool.Build().Start(reco.Args{srcDir, buildVars.wait, buildVars.comment})
 	if err != nil {
 		exitWithError(err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,7 +15,7 @@ var (
 	buildVars = struct {
 		wait    bool
 		force   bool
-		comment string
+		message string
 	}{
 		wait: true,
 	}
@@ -75,7 +75,7 @@ var (
 func init() {
 	buildCmdStart.PersistentFlags().BoolVarP(&buildVars.wait, "wait", "w", buildVars.wait, "Wait for the build to complete. If wait=false, logs will only be displayed up to where the build is started and assigned its unique ID. Use 'reco build list' to check the status of your builds")
 	buildCmdStart.PersistentFlags().BoolVarP(&buildVars.force, "force", "f", buildVars.force, "Force a build to start. Ignore source code validation")
-	buildCmdStart.PersistentFlags().StringVarP(&buildVars.comment, "comment", "m", buildVars.comment, "Add a comment to describe this build's purpose")
+	buildCmdStart.PersistentFlags().StringVarP(&buildVars.message, "message", "m", buildVars.message, "Add a message to describe this build's purpose")
 
 	buildCmd := genDevCommand("build", "build", "b", "builds")
 	buildCmd.AddCommand(genListSubcommand("builds", tool.Build()))
@@ -92,7 +92,7 @@ func startBuild(cmd *cobra.Command, args []string) {
 		exitWithError(errInvalidSourceDirectory)
 	}
 
-	id, err := tool.Build().Start(reco.Args{srcDir, buildVars.wait, buildVars.comment})
+	id, err := tool.Build().Start(reco.Args{srcDir, buildVars.wait, buildVars.message})
 	if err != nil {
 		exitWithError(err)
 	}

--- a/job.go
+++ b/job.go
@@ -57,6 +57,7 @@ type jobInfo struct {
 	Command   string
 	Build     string
 	IPAddress string
+	Comment   string
 }
 
 // UnmarshalJSON customizes JSON decoding for BuildInfo.
@@ -77,6 +78,7 @@ func (ji *jobInfo) UnmarshalJSON(b []byte) error {
 	ji.Project = str.Project.Name
 	ji.Command = str.Command
 	ji.IPAddress = str.IPAddress
+	ji.Comment = str.Comment
 	if str.Build.ID != "" {
 		ji.Build = str.Build.ID
 	}

--- a/job.go
+++ b/job.go
@@ -57,7 +57,7 @@ type jobInfo struct {
 	Command   string
 	Build     string
 	IPAddress string
-	Comment   string
+	Message   string
 }
 
 // UnmarshalJSON customizes JSON decoding for BuildInfo.
@@ -78,7 +78,7 @@ func (ji *jobInfo) UnmarshalJSON(b []byte) error {
 	ji.Project = str.Project.Name
 	ji.Command = str.Command
 	ji.IPAddress = str.IPAddress
-	ji.Comment = str.Comment
+	ji.Message = str.Message
 	if str.Build.ID != "" {
 		ji.Build = str.Build.ID
 	}

--- a/request.go
+++ b/request.go
@@ -174,7 +174,7 @@ type apiResponse struct {
 	} `json:"build,omitempty"`
 	// workaround for deployments
 	// TODO: fix on platform
-	Comment   string  `json:"comment"`
+	Message   string  `json:"message"`
 	Events    []event `json:"events,omitempty"`
 	Command   string  `json:"command,omitempty"`
 	IPAddress string  `json:"ip_address,omitempty"`

--- a/request.go
+++ b/request.go
@@ -174,6 +174,7 @@ type apiResponse struct {
 	} `json:"build,omitempty"`
 	// workaround for deployments
 	// TODO: fix on platform
+	Comment   string  `json:"comment"`
 	Events    []event `json:"events,omitempty"`
 	Command   string  `json:"command,omitempty"`
 	IPAddress string  `json:"ip_address,omitempty"`


### PR DESCRIPTION
This PR lets you set a comment during build creation so that you can identify them or their purpose more easily.