### PR TITLE
add ability to view build reports

### DIFF
--- a/build.go
+++ b/build.go
@@ -152,17 +152,17 @@ func (b buildJob) Report(id string) (string, error) {
 		return "", errors.New("Unknown error occured")
 	}
 
-	var ApiResp struct {
+	var apiResp struct {
 		Value struct {
 			Report string `json:"report"`
 		} `json:"value"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&ApiResp)
+	err = json.NewDecoder(resp.Body).Decode(&apiResp)
 	if err != nil {
 		return "", err
 	}
 
-	validJSONReport := strings.Replace(ApiResp.Value.Report, "\\", "", -1)
+	validJSONReport := strings.Replace(apiResp.Value.Report, "\\", "", -1)
 	var prettyJSONReport bytes.Buffer
 	err = json.Indent(&prettyJSONReport, []byte(validJSONReport), "", "\t")
 	if err != nil {

--- a/build.go
+++ b/build.go
@@ -169,5 +169,5 @@ func (b buildJob) Report(id string) (string, error) {
 		return "", err
 	}
 
-	return string(prettyJSONReport.Bytes()), nil
+	return prettyJSONReport.String(), nil
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -45,6 +45,14 @@ var (
 		},
 	}
 
+	buildCmdReport = &cobra.Command{
+		Use:     fmt.Sprintf("report [build_ID]"),
+		Aliases: []string{"reports"},
+		Short:   fmt.Sprintf("View reports for a completed build"),
+		Long:    fmt.Sprintf("View reports for a completed build, containing area and resource utilisation figures."),
+		Run:     openReport,
+	}
+
 	buildLogPreRun = func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			exitWithError("ID required")
@@ -82,6 +90,7 @@ func init() {
 	buildCmd.AddCommand(buildCmdLog)
 	buildCmd.AddCommand(buildCmdStop)
 	buildCmd.AddCommand(buildCmdStart)
+	buildCmd.AddCommand(buildCmdReport)
 	buildCmd.PersistentFlags().StringVar(&project, "project", project, "Project to use. If unset, the active project is used")
 
 	RootCmd.AddCommand(buildCmd)
@@ -144,4 +153,17 @@ func hasMain(dir string) bool {
 		}
 	}
 	return foundMain
+}
+
+func openReport(_ *cobra.Command, args []string) {
+	if len(args) != 1 {
+		exitWithError("ID required")
+	}
+
+	report, err := tool.Build().(reco.BuildReporter).Report(args[0])
+	if err != nil {
+		exitWithError(err)
+	}
+	logger.Std.Printf("Build Report: %s", report)
+
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -164,6 +164,6 @@ func openReport(_ *cobra.Command, args []string) {
 	if err != nil {
 		exitWithError(err)
 	}
-	logger.Std.Printf("Build Report: %s", report)
 
+	logger.Std.Printf("Build Report: %s", report)
 }

--- a/request.go
+++ b/request.go
@@ -47,6 +47,11 @@ func (p Endpoint) Graph() string {
 	return p.Append("{id}", "graph")
 }
 
+// Report returns report endpoint.
+func (p Endpoint) Report() string {
+	return p.Append("{id}", "reports")
+}
+
 var (
 	endpoints = struct {
 		builds, deployments, projects, simulations, graphs, users Endpoint


### PR DESCRIPTION
This PR adds the `reco build report <id>` command which allows a user to view build reports for a completed build. These reports include utilisation of various FPGA components.

Sample output:
```
$ reco build report e9c2a4c0-f6fb-4efc-9461-f47dc1dc16b3
Build Report: {
	"partName": "xcvu9p-flgb2104-2-i",
	"lutSummary": {
		"used": 809,
		"detail": {
			"lutLogic": {
				"used": 808,
				"available": 1182240,
				"description": "LUT as Logic",
				"utilisation": 0.07
			},
			"lutMemory": {
				"used": 1,
				"available": 591840,
				"description": "LUT as Memory",
				"utilisation": 0.01
			}
		},
		"available": 1182240,
		"description": "CLB LUTs",
		"utilisation": 0.07
	},
	"moduleName": "reconfigure_io_sdaccel_builder_stub_0_1",
	"regSummary": {
		"used": 1765,
		"detail": {
			"regLatch": {
				"used": 0,
				"available": 2364480,
				"description": "Register as Latch",
				"utilisation": 0
			},
			"regFlipFlop": {
				"used": 1765,
				"available": 2364480,
				"description": "Register as Flip Flop",
				"utilisation": 0.07
			}
		},
		"available": 2364480,
		"description": "CLB Registers",
		"utilisation": 0.07
	},
	"blockRamSummary": {
		"used": 1,
		"detail": {
			"blockRamB18": {
				"used": 0,
				"available": 4320,
				"description": "RAMB18",
				"utilisation": 0
			},
			"blockRamB36": {
				"used": 1,
				"available": 2160,
				"description": "RAMB36/FIFO",
				"utilisation": 0.05
			}
		},
		"available": 2160,
		"description": "Block RAM Tile",
		"utilisation": 0.05
	},
	"dspBlockSummary": {
		"used": 0,
		"available": 6840,
		"description": "DSPs",
		"utilisation": 0
	},
	"ultraRamSummary": {
		"used": 0,
		"available": 960,
		"description": "URAM",
		"utilisation": 0
	},
	"weightedAverage": {
		"used": 5257,
		"available": 9067200,
		"description": "Weighted Average",
		"utilisation": 0.06
	}
}
```